### PR TITLE
Fix: ACCESS_MEDIA_LOCATION 권한 추가하여 이미지 EXIF 누락되는 현상 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" 
         android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -144,6 +144,7 @@ dependencies {
 
     // DataStore
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.exifinterface)
 
     // Room
     implementation(libs.androidx.room.runtime)

--- a/data/src/main/java/com/nexters/fooddiary/data/repository/PhotoRepositoryImpl.kt
+++ b/data/src/main/java/com/nexters/fooddiary/data/repository/PhotoRepositoryImpl.kt
@@ -2,6 +2,8 @@ package com.nexters.fooddiary.data.repository
 
 import android.content.Context
 import android.net.Uri
+import android.util.Log
+import androidx.exifinterface.media.ExifInterface
 import com.nexters.fooddiary.data.local.upload.PhotoUploadDao
 import com.nexters.fooddiary.data.local.upload.PhotoUploadEntity
 import com.nexters.fooddiary.data.local.upload.UploadStatus
@@ -17,6 +19,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.ByteArrayInputStream
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
@@ -128,6 +131,7 @@ internal class PhotoRepositoryImpl @Inject constructor(
     ): MultipartBody.Part? = try {
         resolver.openInputStream(uri)?.use { inputStream ->
             val bytes = inputStream.readBytes()
+            logExifIfDebug(uri, bytes)
             val contentType = resolver.getType(uri) ?: MIME_TYPE_IMAGE_JPEG
             val body = bytes.toRequestBody(contentType.toMediaTypeOrNull(), 0, bytes.size)
             MultipartBody.Part.createFormData(MULTIPART_FIELD_PHOTOS, "photo_$index.jpg", body)
@@ -136,12 +140,33 @@ internal class PhotoRepositoryImpl @Inject constructor(
         null
     }
 
+    private fun logExifIfDebug(uri: Uri, bytes: ByteArray) {
+        if (!isDebug) return
+
+        runCatching {
+            ByteArrayInputStream(bytes).use { stream ->
+                val exif = ExifInterface(stream)
+                val latLong = exif.latLong
+                Log.d(
+                    TAG,
+                    "EXIF uri=$uri, dateTimeOriginal=${exif.getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL)}, " +
+                        "dateTimeDigitized=${exif.getAttribute(ExifInterface.TAG_DATETIME_DIGITIZED)}, " +
+                        "dateTime=${exif.getAttribute(ExifInterface.TAG_DATETIME)}, " +
+                        "latitude=${latLong?.getOrNull(0)}, longitude=${latLong?.getOrNull(1)}"
+                )
+            }
+        }.onFailure { error ->
+            Log.w(TAG, "Failed to read EXIF for uri=$uri", error)
+        }
+    }
+
     private sealed class PartsResult {
         data class Success(val parts: List<MultipartBody.Part>) : PartsResult()
         data class Failure(val error: Exception) : PartsResult()
     }
 }
 
+private const val TAG = "PhotoRepository"
 private const val MEDIA_TYPE_TEXT_PLAIN = "text/plain"
 private const val MIME_TYPE_IMAGE_JPEG = "image/jpeg"
 private const val MULTIPART_FIELD_PHOTOS = "photos"


### PR DESCRIPTION
## 변경 내용
앱에서 이미지를 읽을 때 위치 EXIF가 누락될 수 있어 ACCESS_MEDIA_LOCATION 권한을 manifest에 추가

## 체크리스트
- [ ] 빌드 정상 동작
- [ ] 불필요한 파일 없음

## Notes
### Draft로 올리는 이유
Android 공식 문서에서는 미디어 위치정보 접근 시 ACCESS_MEDIA_LOCATION runtime 요청이 필요하다고 안내 중
[Android Developers - Access media files from shared storage](https://developer.android.com/training/data-storage/shared/media)

실기기 확인 과정에서는 기존 미디어 읽기 권한 허용 후 ACCESS_MEDIA_LOCATION 요청 시 별도 팝업이 보이지 않는 사례가 있고
Stack Overflow에도 보고되어 있음

[ACCESS_MEDIA_LOCATION permission request is not showing prompt](https://stackoverflow.com/questions/64374469/access-media-location-permission-request-is-not-showing-prompt)
[Why is no permission box shown when I request ACCESS_MEDIA_LOCATION permission?](https://stackoverflow.com/questions/64445054/why-is-no-permission-box-shown-when-i-request-access-media-location-permission)

추가로 확인해봐야될 내용이 있을지 논의가 필요할 것 같아서 Draft로 올려봅니다~!
