### PR TITLE
[FD-310] 이미지 등록후 detail 재진입시 날짜 초기화 되지 않도록 수정

### DIFF
--- a/presentation/detail/src/main/java/com/nexters/fooddiary/presentation/detail/DetailScreen.kt
+++ b/presentation/detail/src/main/java/com/nexters/fooddiary/presentation/detail/DetailScreen.kt
@@ -121,10 +121,11 @@ internal fun DetailScreen(
         mutableStateOf<String?>(initialDateString)
     }
 
-    LaunchedEffect(initialDateToSync) {
-        val dateString = initialDateToSync ?: return@LaunchedEffect
-        viewModel.syncSelectedDate(dateString)
-        initialDateToSync = null
+    initialDateToSync?.let { dateString ->
+        LaunchedEffect(dateString) {
+            viewModel.syncSelectedDate(dateString)
+            initialDateToSync = null
+        }
     }
 
     LaunchedEffect(state.selectedDate) {

--- a/presentation/detail/src/main/java/com/nexters/fooddiary/presentation/detail/DetailScreen.kt
+++ b/presentation/detail/src/main/java/com/nexters/fooddiary/presentation/detail/DetailScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
@@ -116,9 +117,14 @@ internal fun DetailScreen(
     val context = LocalContext.current
     val currentContext by rememberUpdatedState(context)
     val currentOnShowToast by rememberUpdatedState(onShowToast)
+    var initialDateToSync by rememberSaveable(initialDateString) {
+        mutableStateOf<String?>(initialDateString)
+    }
 
-    LaunchedEffect(initialDateString) {
-        viewModel.syncSelectedDate(initialDateString)
+    LaunchedEffect(initialDateToSync) {
+        val dateString = initialDateToSync ?: return@LaunchedEffect
+        viewModel.syncSelectedDate(dateString)
+        initialDateToSync = null
     }
 
     LaunchedEffect(state.selectedDate) {
@@ -151,8 +157,8 @@ internal fun DetailScreen(
                 DetailEvent.ShareLinkEmpty -> {
                     currentOnShowToast(currentContext.getString(R.string.detail_share_map_link_empty))
                 }
-                DetailEvent.NavigateToImagePicker -> {
-                    onNavigateToImagePicker(state.selectedDate)
+                is DetailEvent.NavigateToImagePicker -> {
+                    onNavigateToImagePicker(event.date)
                 }
                 is DetailEvent.NavigateToModify -> {
                     onNavigateToModify(event.diaryId)

--- a/presentation/detail/src/main/java/com/nexters/fooddiary/presentation/detail/DetailViewModel.kt
+++ b/presentation/detail/src/main/java/com/nexters/fooddiary/presentation/detail/DetailViewModel.kt
@@ -33,7 +33,7 @@ sealed interface DetailEvent {
     data class CopyMapLink(val mapLink: String) : DetailEvent
     data class ShareMapLink(val place: String, val mapLink: String) : DetailEvent
     data object ShareLinkEmpty : DetailEvent
-    data object NavigateToImagePicker : DetailEvent
+    data class NavigateToImagePicker(val date: LocalDate) : DetailEvent
     data class NavigateToModify(val diaryId: String) : DetailEvent
     data class DeleteSuccess(val date: LocalDate) : DetailEvent
     data object DeleteEmpty : DetailEvent
@@ -105,7 +105,7 @@ class DetailViewModel @AssistedInject constructor(
     }
 
     fun onAddPhoto(slot: MealSlot, date: LocalDate) {
-        _events.tryEmit(DetailEvent.NavigateToImagePicker)
+        _events.tryEmit(DetailEvent.NavigateToImagePicker(date))
     }
 
     fun onEditClick(slot: MealSlot, date: LocalDate) {


### PR DESCRIPTION
## 변경 내용
- Detail 진입 시 전달되는 initialDateString를 화면에서 다시 적용하는 타이밍이 복귀 플로우에서 재실행되면서, 이미 사용자가 이동해 둔 selectedDate를 덮어쓰는 케이스 수정
- 이미지 피커 이동 이벤트가 화면 상태를 직접 참조해 stale date를 사용할 가능성도 존재
- 초기 route 날짜 동기화는 1회 소비되도록 변경
- 이미지 피커 이동 시 날짜를 이벤트 payload로 명시 전달

## 체크리스트
- [x] 빌드 정상 동작
- [x] 불필요한 파일 없음

