### PR TITLE
feat(push): 일일 기록 리마인더 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:maxSdkVersion="32" />
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name=".FoodDiaryApplication"
@@ -45,8 +46,29 @@
                 <data android:host="image" />
                 <data android:scheme="fooddiary" />
                 <data android:host="detail" />
+                <data android:scheme="fooddiary" />
+                <data android:host="home" />
             </intent-filter>
         </activity>
+
+        <receiver
+            android:name=".push.DailyRecordReminderReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.nexters.fooddiary.action.DAILY_RECORD_REMINDER" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".push.DailyRecordReminderSystemReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+                <action android:name="android.intent.action.TIME_SET" />
+            </intent-filter>
+        </receiver>
 
         <service
             android:name=".push.FoodDiaryFirebaseMessagingService"

--- a/app/src/main/java/com/nexters/fooddiary/MainActivity.kt
+++ b/app/src/main/java/com/nexters/fooddiary/MainActivity.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.ui.platform.LocalContext
 import com.nexters.fooddiary.core.ui.alert.AppDialogData
 import com.nexters.fooddiary.core.ui.alert.DeleteAccountDialogData
 import com.nexters.fooddiary.core.ui.alert.DialogData
@@ -28,6 +27,8 @@ import com.nexters.fooddiary.core.ui.component.FoodDiarySnackBar
 import com.nexters.fooddiary.core.ui.theme.FoodDiaryTheme
 import com.nexters.fooddiary.navigation.FoodDiaryNavHost
 import com.nexters.fooddiary.navigation.NavigationConstants
+import com.nexters.fooddiary.push.FoodDiaryPushExtras
+import com.nexters.fooddiary.push.FoodDiaryPushTypes
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import dagger.hilt.android.AndroidEntryPoint
@@ -127,24 +128,28 @@ class MainActivity : ComponentActivity() {
             return directDeepLink
         }
 
-        val pushType = intent?.getStringExtra(PUSH_TYPE_EXTRA).orEmpty()
-        val pushDiaryDate = intent?.getStringExtra(PUSH_DIARY_DATE_EXTRA).orEmpty()
-        if (pushType != PUSH_TYPE_ANALYSIS_COMPLETE || pushDiaryDate.isBlank()) {
-            return null
+        val pushType = intent?.getStringExtra(FoodDiaryPushExtras.PUSH_TYPE).orEmpty()
+        val pushDiaryDate = intent?.getStringExtra(FoodDiaryPushExtras.PUSH_DIARY_DATE).orEmpty()
+        return when {
+            pushType == FoodDiaryPushTypes.DAILY_RECORD_REMINDER -> {
+                intent?.removeExtra(FoodDiaryPushExtras.PUSH_TYPE)
+                Uri.Builder()
+                    .scheme(NavigationConstants.DEEP_LINK_SCHEME)
+                    .authority(NavigationConstants.DEEP_LINK_HOST_HOME)
+                    .build()
+            }
+
+            pushType == FoodDiaryPushTypes.ANALYSIS_COMPLETE && pushDiaryDate.isNotBlank() -> {
+                intent?.removeExtra(FoodDiaryPushExtras.PUSH_TYPE)
+                intent?.removeExtra(FoodDiaryPushExtras.PUSH_DIARY_DATE)
+                Uri.Builder()
+                    .scheme(NavigationConstants.DEEP_LINK_SCHEME)
+                    .authority(NavigationConstants.DEEP_LINK_HOST_DETAIL)
+                    .appendQueryParameter(NavigationConstants.DEEP_LINK_QUERY_DATE, pushDiaryDate)
+                    .build()
+            }
+
+            else -> null
         }
-
-        intent?.removeExtra(PUSH_TYPE_EXTRA)
-        intent?.removeExtra(PUSH_DIARY_DATE_EXTRA)
-        return Uri.Builder()
-            .scheme("fooddiary")
-            .authority(NavigationConstants.DEEP_LINK_HOST_DETAIL)
-            .appendQueryParameter(NavigationConstants.DEEP_LINK_QUERY_DATE, pushDiaryDate)
-            .build()
-    }
-
-    companion object {
-        private const val PUSH_TYPE_EXTRA = "push_type"
-        private const val PUSH_DIARY_DATE_EXTRA = "push_diary_date"
-        private const val PUSH_TYPE_ANALYSIS_COMPLETE = "analysis_complete"
     }
 }

--- a/app/src/main/java/com/nexters/fooddiary/navigation/FoodDiaryNavHost.kt
+++ b/app/src/main/java/com/nexters/fooddiary/navigation/FoodDiaryNavHost.kt
@@ -43,6 +43,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import com.nexters.fooddiary.core.ui.alert.AppDialogData
 import com.nexters.fooddiary.core.ui.alert.SnackBarData
+import com.nexters.fooddiary.push.DailyRecordReminderScheduler
 import com.nexters.fooddiary.push.PushSyncEventBus
 import com.nexters.fooddiary.presentation.auth.AuthUiState
 import com.nexters.fooddiary.presentation.auth.navigation.LoginRoute
@@ -95,6 +96,7 @@ fun FoodDiaryNavHost(
     var authUiState by remember { mutableStateOf<AuthUiState?>(null) }
     var deleteAccountRequestId by remember { mutableIntStateOf(0) }
     var onboardingCompleteEventId by remember { mutableIntStateOf(0) }
+    var pendingHomeDeepLink by remember { mutableStateOf(initialDeepLink.isHomeDeepLink()) }
     var pendingDetailDate by remember { mutableStateOf(initialDeepLink.getDetailDateOrNull()) }
     var isHomeMonthlyCalendarView by rememberSaveable { mutableStateOf(false) }
     var hasNavigatedFromSplash by remember { mutableStateOf(false) }
@@ -114,6 +116,8 @@ fun FoodDiaryNavHost(
         currentDestination?.hierarchy?.any { it.hasRoute(InsightRoute::class) } == true
     val isLoginRoute =
         currentDestination?.hierarchy?.any { it.hasRoute(LoginRoute::class) } == true
+    val isOnboardingRoute =
+        currentDestination?.hierarchy?.any { it.hasRoute(OnboardingRoute::class) } == true
     val shouldShowHomeInsightBottomBar = isHomeRoute || isInsightRoute
     val shouldHandleAppExitBack = isHomeRoute || isInsightRoute
     val selectedTab = if (isInsightRoute) HomeInsightTab.INSIGHT else HomeInsightTab.HOME
@@ -136,11 +140,28 @@ fun FoodDiaryNavHost(
         }
     }
 
+    val navigateToPendingHomeIfNeeded: () -> Unit = {
+        val canNavigateToHome = !isLoginRoute && authUiState?.isAuthenticated != false
+        if (pendingHomeDeepLink && canNavigateToHome) {
+            navController.navigate(HomeRoute) {
+                popUpTo(0) { inclusive = false }
+                launchSingleTop = true
+            }
+            pendingHomeDeepLink = false
+        }
+    }
+
     fun navigateToImagePicker(dateString: String?) {
         navController.navigate(ImagePickerRoute(dateString = dateString))
     }
 
     LaunchedEffect(initialDeepLink) {
+        if (initialDeepLink.isHomeDeepLink()) {
+            pendingHomeDeepLink = true
+            if (hasNavigatedFromSplash) {
+                navigateToPendingHomeIfNeeded()
+            }
+        }
         initialDeepLink.getDetailDateOrNull()?.let { date ->
             pendingDetailDate = date
             if (hasNavigatedFromSplash) {
@@ -158,6 +179,24 @@ fun FoodDiaryNavHost(
     LaunchedEffect(shouldHandleAppExitBack) {
         if (!shouldHandleAppExitBack) {
             lastExitBackPressedAt = 0L
+        }
+    }
+
+    LaunchedEffect(
+        isHomeRoute,
+        isLoginRoute,
+        isOnboardingRoute,
+        authUiState?.isAuthenticated
+    ) {
+        val shouldEnableDailyRecordReminder = when {
+            isHomeRoute -> authUiState?.isAuthenticated != false
+            isOnboardingRoute -> false
+            isLoginRoute -> authUiState?.isAuthenticated == true
+            else -> null
+        }
+
+        shouldEnableDailyRecordReminder?.let { enabled ->
+            DailyRecordReminderScheduler.setReminderEnabled(context, enabled)
         }
     }
 
@@ -228,6 +267,7 @@ fun FoodDiaryNavHost(
                     launchSingleTop = true
                 }
                 if (destination == HomeRoute) {
+                    pendingHomeDeepLink = false
                     navigateToPendingDetailIfNeeded()
                 }
             }
@@ -293,6 +333,7 @@ fun FoodDiaryNavHost(
                         navController.navigate(HomeRoute) {
                             popUpTo(SplashRoute) { inclusive = true }
                         }
+                        pendingHomeDeepLink = false
                         navigateToPendingDetailIfNeeded()
                     },
                     onNavigateToLogin = {
@@ -318,6 +359,7 @@ fun FoodDiaryNavHost(
                             popUpTo(OnboardingRoute) { inclusive = true }
                             launchSingleTop = true
                         }
+                        pendingHomeDeepLink = false
                         navigateToPendingDetailIfNeeded()
                     }
                 )
@@ -491,6 +533,10 @@ private fun Uri?.getDetailDateOrNull(): String? {
     if (this?.host != NavigationConstants.DEEP_LINK_HOST_DETAIL) return null
     return getQueryParameter(NavigationConstants.DEEP_LINK_QUERY_DATE)
         ?.takeIf { it.isNotBlank() }
+}
+
+private fun Uri?.isHomeDeepLink(): Boolean {
+    return this?.host == NavigationConstants.DEEP_LINK_HOST_HOME
 }
 
 private const val EXIT_CONFIRMATION_WINDOW_MILLIS = 2_000L

--- a/app/src/main/java/com/nexters/fooddiary/navigation/NavigationConstants.kt
+++ b/app/src/main/java/com/nexters/fooddiary/navigation/NavigationConstants.kt
@@ -1,7 +1,9 @@
 package com.nexters.fooddiary.navigation
 
 internal object NavigationConstants {
+    const val DEEP_LINK_SCHEME = "fooddiary"
     const val DEEP_LINK_HOST_IMAGE = "image"
     const val DEEP_LINK_HOST_DETAIL = "detail"
+    const val DEEP_LINK_HOST_HOME = "home"
     const val DEEP_LINK_QUERY_DATE = "date"
 }

--- a/app/src/main/java/com/nexters/fooddiary/push/DailyRecordReminderReceiver.kt
+++ b/app/src/main/java/com/nexters/fooddiary/push/DailyRecordReminderReceiver.kt
@@ -1,0 +1,36 @@
+package com.nexters.fooddiary.push
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.nexters.fooddiary.R
+
+class DailyRecordReminderReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        when (intent?.action) {
+            DailyRecordReminderScheduler.ACTION_DAILY_RECORD_REMINDER -> handleDailyRecordReminder(context)
+        }
+    }
+
+    private fun handleDailyRecordReminder(context: Context) {
+        if (DailyRecordReminderScheduler.isReminderEnabled(context)) {
+            showDailyRecordReminder(context)
+        }
+        DailyRecordReminderScheduler.scheduleNext(context)
+    }
+
+    private fun showDailyRecordReminder(context: Context) {
+        val title = context.getString(R.string.push_daily_record_reminder_title)
+        val body = context.getString(R.string.push_daily_record_reminder_body)
+        FoodDiaryNotificationHelper.show(
+            context = context,
+            title = title,
+            body = body,
+            contentIntent = FoodDiaryNotificationHelper.createHomeLaunchIntent(
+                context = context,
+                pushType = FoodDiaryPushTypes.DAILY_RECORD_REMINDER
+            ),
+            notificationId = FoodDiaryPushTypes.DAILY_RECORD_REMINDER.hashCode(),
+        )
+    }
+}

--- a/app/src/main/java/com/nexters/fooddiary/push/DailyRecordReminderScheduler.kt
+++ b/app/src/main/java/com/nexters/fooddiary/push/DailyRecordReminderScheduler.kt
@@ -1,0 +1,80 @@
+package com.nexters.fooddiary.push
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import java.time.LocalTime
+import java.time.ZonedDateTime
+
+internal object DailyRecordReminderScheduler {
+    const val ACTION_DAILY_RECORD_REMINDER =
+        "com.nexters.fooddiary.action.DAILY_RECORD_REMINDER"
+
+    private const val REQUEST_CODE = 329
+    private const val PREFS_NAME = "daily_record_reminder"
+    private const val KEY_REMINDER_ENABLED = "reminder_enabled"
+    private val reminderTime = LocalTime.of(21, 0)
+
+    fun setReminderEnabled(context: Context, enabled: Boolean) {
+        context.reminderPreferences.edit()
+            .putBoolean(KEY_REMINDER_ENABLED, enabled)
+            .apply()
+
+        if (enabled) {
+            scheduleNext(context)
+        } else {
+            cancel(context)
+        }
+    }
+
+    fun scheduleNext(context: Context) {
+        if (!isReminderEnabled(context)) return
+
+        val alarmManager = context.getSystemService(AlarmManager::class.java)
+        val triggerAtMillis = nextTriggerAtMillis(ZonedDateTime.now())
+        alarmManager.setAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            triggerAtMillis,
+            createPendingIntent(context)
+        )
+    }
+
+    internal fun nextTriggerAtMillis(now: ZonedDateTime): Long {
+        val todayReminder = now
+            .withHour(reminderTime.hour)
+            .withMinute(reminderTime.minute)
+            .withSecond(0)
+            .withNano(0)
+        val nextReminder = if (now.isBefore(todayReminder)) {
+            todayReminder
+        } else {
+            todayReminder.plusDays(1)
+        }
+        return nextReminder.toInstant().toEpochMilli()
+    }
+
+    internal fun isReminderEnabled(context: Context): Boolean {
+        return context.reminderPreferences.getBoolean(KEY_REMINDER_ENABLED, false)
+    }
+
+    private fun cancel(context: Context) {
+        val alarmManager = context.getSystemService(AlarmManager::class.java)
+        alarmManager.cancel(createPendingIntent(context))
+    }
+
+    private fun createPendingIntent(context: Context): PendingIntent {
+        val intent = Intent(context, DailyRecordReminderReceiver::class.java).apply {
+            action = ACTION_DAILY_RECORD_REMINDER
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            REQUEST_CODE,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    private val Context.reminderPreferences
+        get() = getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+}

--- a/app/src/main/java/com/nexters/fooddiary/push/DailyRecordReminderSystemReceiver.kt
+++ b/app/src/main/java/com/nexters/fooddiary/push/DailyRecordReminderSystemReceiver.kt
@@ -1,0 +1,18 @@
+package com.nexters.fooddiary.push
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+class DailyRecordReminderSystemReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        when (intent?.action) {
+            Intent.ACTION_BOOT_COMPLETED,
+            Intent.ACTION_MY_PACKAGE_REPLACED,
+            Intent.ACTION_TIMEZONE_CHANGED,
+            Intent.ACTION_TIME_CHANGED -> {
+                DailyRecordReminderScheduler.scheduleNext(context)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nexters/fooddiary/push/FoodDiaryFirebaseMessagingService.kt
+++ b/app/src/main/java/com/nexters/fooddiary/push/FoodDiaryFirebaseMessagingService.kt
@@ -1,24 +1,9 @@
 package com.nexters.fooddiary.push
 
-import android.Manifest
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
-import android.content.Intent
-import android.content.pm.PackageManager
-import android.graphics.BitmapFactory
-import android.net.Uri
-import android.os.Build
-import android.util.Log
-import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
-import androidx.core.content.ContextCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import com.nexters.fooddiary.MainActivity
 import com.nexters.fooddiary.R
 import com.nexters.fooddiary.domain.usecase.SyncDeviceTokenUseCase
-import com.nexters.fooddiary.navigation.NavigationConstants
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -29,7 +14,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeParseException
 import javax.inject.Inject
-import com.nexters.fooddiary.core.ui.R as coreR
 
 @AndroidEntryPoint
 class FoodDiaryFirebaseMessagingService : FirebaseMessagingService() {
@@ -41,10 +25,10 @@ class FoodDiaryFirebaseMessagingService : FirebaseMessagingService() {
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
 
-        val type = message.data["type"].orEmpty()
-        val diaryDate = message.data["diary_date"].orEmpty()
+        val type = message.data[TYPE_DATA_KEY].orEmpty()
+        val diaryDate = message.data[DIARY_DATE_DATA_KEY].orEmpty()
 
-        if (type == ANALYSIS_COMPLETE_TYPE && diaryDate.isNotBlank()) {
+        if (type == FoodDiaryPushTypes.ANALYSIS_COMPLETE && diaryDate.isNotBlank()) {
             PushSyncEventBus.publishAnalysisComplete(diaryDate)
         }
 
@@ -66,23 +50,16 @@ class FoodDiaryFirebaseMessagingService : FirebaseMessagingService() {
     }
 
     companion object {
-        private const val TAG = "FD-FCM-Service"
-        private const val DEFAULT_CHANNEL_ID = "food_diary_general"
-        private const val ANALYSIS_COMPLETE_TYPE = "analysis_complete"
+        private const val DIARY_DATE_DATA_KEY = "diary_date"
+        private const val TYPE_DATA_KEY = "type"
     }
 
     private fun showNotification(message: RemoteMessage) {
-        if (!hasNotificationPermission()) {
-            return
-        }
-
-        val type = message.data["type"].orEmpty()
-        val diaryDate = message.data["diary_date"].orEmpty()
+        val type = message.data[TYPE_DATA_KEY].orEmpty()
+        val diaryDate = message.data[DIARY_DATE_DATA_KEY].orEmpty()
         val channelId = message.notification?.channelId
             ?.takeIf { it.isNotBlank() }
-            ?: DEFAULT_CHANNEL_ID
-
-        ensureNotificationChannel(channelId)
+            ?: FoodDiaryNotificationHelper.DEFAULT_CHANNEL_ID
 
         val title = message.notification?.title
             ?.takeIf { it.isNotBlank() }
@@ -91,52 +68,27 @@ class FoodDiaryFirebaseMessagingService : FirebaseMessagingService() {
             ?.takeIf { it.isNotBlank() }
             ?: getDefaultBody(type, diaryDate)
 
-        val pendingIntent = PendingIntent.getActivity(
-            this,
-            (type + diaryDate).hashCode(),
-            createLaunchIntent(type, diaryDate),
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        FoodDiaryNotificationHelper.show(
+            context = this,
+            channelId = channelId,
+            title = title,
+            body = body,
+            contentIntent = createLaunchIntent(type, diaryDate),
+            notificationId = (type + diaryDate + title).hashCode(),
         )
-
-        val notification = NotificationCompat.Builder(this, channelId)
-            .setSmallIcon(coreR.drawable.ic_notification)
-            .setLargeIcon(BitmapFactory.decodeResource(resources, coreR.drawable.ic_app_icon))
-            .setContentTitle(title)
-            .setContentText(body)
-            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
-            .setAutoCancel(true)
-            .setContentIntent(pendingIntent)
-            .build()
-
-        NotificationManagerCompat.from(this).notify((type + diaryDate + title).hashCode(), notification)
-    }
-
-    private fun createLaunchIntent(type: String, diaryDate: String): Intent {
-        val deepLink = Uri.Builder()
-            .scheme("fooddiary")
-            .authority(NavigationConstants.DEEP_LINK_HOST_DETAIL)
-            .appendQueryParameter(NavigationConstants.DEEP_LINK_QUERY_DATE, diaryDate)
-            .build()
-
-        return Intent(this, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-            data = deepLink
-            putExtra("push_type", type)
-            putExtra("push_diary_date", diaryDate)
-        }
     }
 
     private fun getDefaultTitle(type: String): String {
         return when (type) {
-            ANALYSIS_COMPLETE_TYPE -> getString(R.string.push_analysis_complete_title)
+            FoodDiaryPushTypes.ANALYSIS_COMPLETE -> getString(R.string.push_analysis_complete_title)
+            FoodDiaryPushTypes.DAILY_RECORD_REMINDER -> getString(R.string.push_daily_record_reminder_title)
             else -> getString(R.string.push_default_title)
         }
     }
 
     private fun getDefaultBody(type: String, diaryDate: String): String {
         return when (type) {
-            ANALYSIS_COMPLETE_TYPE -> {
+            FoodDiaryPushTypes.ANALYSIS_COMPLETE -> {
                 val displayDate = formatDiaryDate(diaryDate) ?: diaryDate
                 if (displayDate.isBlank()) {
                     getString(R.string.push_analysis_complete_body_no_date)
@@ -145,6 +97,7 @@ class FoodDiaryFirebaseMessagingService : FirebaseMessagingService() {
                 }
             }
 
+            FoodDiaryPushTypes.DAILY_RECORD_REMINDER -> getString(R.string.push_daily_record_reminder_body)
             else -> getString(R.string.push_default_body)
         }
     }
@@ -160,25 +113,17 @@ class FoodDiaryFirebaseMessagingService : FirebaseMessagingService() {
         }
     }
 
-    private fun ensureNotificationChannel(channelId: String) {
-        val manager = getSystemService(NotificationManager::class.java)
-        if (manager.getNotificationChannel(channelId) != null) return
-
-        val channel = NotificationChannel(
-            channelId,
-            getString(R.string.push_channel_name),
-            NotificationManager.IMPORTANCE_HIGH
-        ).apply {
-            description = getString(R.string.push_channel_description)
+    private fun createLaunchIntent(type: String, diaryDate: String) = when (type) {
+        FoodDiaryPushTypes.DAILY_RECORD_REMINDER -> {
+            FoodDiaryNotificationHelper.createHomeLaunchIntent(this, type)
         }
-        manager.createNotificationChannel(channel)
-    }
 
-    private fun hasNotificationPermission(): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return true
-        return ContextCompat.checkSelfPermission(
-            this,
-            Manifest.permission.POST_NOTIFICATIONS
-        ) == PackageManager.PERMISSION_GRANTED
+        else -> {
+            FoodDiaryNotificationHelper.createDetailLaunchIntent(
+                context = this,
+                pushType = type,
+                diaryDate = diaryDate
+            )
+        }
     }
 }

--- a/app/src/main/java/com/nexters/fooddiary/push/FoodDiaryNotificationHelper.kt
+++ b/app/src/main/java/com/nexters/fooddiary/push/FoodDiaryNotificationHelper.kt
@@ -1,0 +1,106 @@
+package com.nexters.fooddiary.push
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.nexters.fooddiary.MainActivity
+import com.nexters.fooddiary.R
+import com.nexters.fooddiary.navigation.NavigationConstants
+import com.nexters.fooddiary.core.ui.R as coreR
+
+internal object FoodDiaryNotificationHelper {
+    const val DEFAULT_CHANNEL_ID = "food_diary_general"
+
+    fun show(
+        context: Context,
+        channelId: String = DEFAULT_CHANNEL_ID,
+        title: String,
+        body: String,
+        contentIntent: Intent,
+        notificationId: Int,
+    ) {
+        if (!context.hasNotificationPermission()) return
+
+        context.ensureNotificationChannel(channelId)
+
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            notificationId,
+            contentIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, channelId)
+            .setSmallIcon(coreR.drawable.ic_notification)
+            .setLargeIcon(BitmapFactory.decodeResource(context.resources, coreR.drawable.ic_app_icon))
+            .setContentTitle(title)
+            .setContentText(body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(notificationId, notification)
+    }
+
+    fun createHomeLaunchIntent(context: Context, pushType: String): Intent {
+        return Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            data = Uri.Builder()
+                .scheme(NavigationConstants.DEEP_LINK_SCHEME)
+                .authority(NavigationConstants.DEEP_LINK_HOST_HOME)
+                .build()
+            putExtra(FoodDiaryPushExtras.PUSH_TYPE, pushType)
+        }
+    }
+
+    fun createDetailLaunchIntent(
+        context: Context,
+        pushType: String,
+        diaryDate: String,
+    ): Intent {
+        return Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            data = Uri.Builder()
+                .scheme(NavigationConstants.DEEP_LINK_SCHEME)
+                .authority(NavigationConstants.DEEP_LINK_HOST_DETAIL)
+                .appendQueryParameter(NavigationConstants.DEEP_LINK_QUERY_DATE, diaryDate)
+                .build()
+            putExtra(FoodDiaryPushExtras.PUSH_TYPE, pushType)
+            putExtra(FoodDiaryPushExtras.PUSH_DIARY_DATE, diaryDate)
+        }
+    }
+
+    private fun Context.ensureNotificationChannel(channelId: String) {
+        val manager = getSystemService(NotificationManager::class.java)
+        if (manager.getNotificationChannel(channelId) != null) return
+
+        val channel = NotificationChannel(
+            channelId,
+            getString(R.string.push_channel_name),
+            NotificationManager.IMPORTANCE_HIGH
+        ).apply {
+            description = getString(R.string.push_channel_description)
+        }
+        manager.createNotificationChannel(channel)
+    }
+
+    private fun Context.hasNotificationPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return true
+        return ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+}

--- a/app/src/main/java/com/nexters/fooddiary/push/FoodDiaryPushTypes.kt
+++ b/app/src/main/java/com/nexters/fooddiary/push/FoodDiaryPushTypes.kt
@@ -1,0 +1,11 @@
+package com.nexters.fooddiary.push
+
+internal object FoodDiaryPushTypes {
+    const val ANALYSIS_COMPLETE = "analysis_complete"
+    const val DAILY_RECORD_REMINDER = "daily_record_reminder"
+}
+
+internal object FoodDiaryPushExtras {
+    const val PUSH_TYPE = "push_type"
+    const val PUSH_DIARY_DATE = "push_diary_date"
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,5 +13,7 @@
     <string name="push_analysis_complete_body">%1$s사진을 AI가 기록을 완료했어요.</string>
     <string name="push_analysis_complete_body_no_date">음식 사진 분석이 완료됐어요.</string>
     <string name="push_analysis_complete_snackbar">AI가 기록을 완료했습니다.</string>
+    <string name="push_daily_record_reminder_title">오늘 먹은 음식, 기록해볼까요?</string>
+    <string name="push_daily_record_reminder_body">하루가 끝나기 전에 오늘의 식사를 남겨보세요.</string>
     <string name="exit_confirm_toast_message">\'뒤로\'버튼 한번 더 누르시면 종료됩니다.</string>
 </resources>

--- a/app/src/test/java/com/nexters/fooddiary/push/DailyRecordReminderSchedulerTest.kt
+++ b/app/src/test/java/com/nexters/fooddiary/push/DailyRecordReminderSchedulerTest.kt
@@ -1,0 +1,32 @@
+package com.nexters.fooddiary.push
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class DailyRecordReminderSchedulerTest {
+    private val zoneId = ZoneId.of("Asia/Seoul")
+
+    @Test
+    fun `next trigger is today 9pm when current time is before 9pm`() {
+        val now = ZonedDateTime.of(2026, 4, 21, 20, 59, 0, 0, zoneId)
+        val expected = ZonedDateTime.of(2026, 4, 21, 21, 0, 0, 0, zoneId)
+
+        assertEquals(
+            expected.toInstant().toEpochMilli(),
+            DailyRecordReminderScheduler.nextTriggerAtMillis(now)
+        )
+    }
+
+    @Test
+    fun `next trigger is tomorrow 9pm when current time is 9pm`() {
+        val now = ZonedDateTime.of(2026, 4, 21, 21, 0, 0, 0, zoneId)
+        val expected = ZonedDateTime.of(2026, 4, 22, 21, 0, 0, 0, zoneId)
+
+        assertEquals(
+            expected.toInstant().toEpochMilli(),
+            DailyRecordReminderScheduler.nextTriggerAtMillis(now)
+        )
+    }
+}


### PR DESCRIPTION
## 요약
- 매일 오후 9시에 오늘의 식사 기록을 유도하는 로컬 리마인더 알림을 추가했습니다.
- 기기 재부팅, 앱 업데이트, 시간대 변경, 시간 변경 후에도 리마인더가 다시 예약되도록 처리했습니다.
- 리마인더 알림 클릭 시 홈 화면으로 이동하고, 기존 AI 분석 완료 푸시는 상세 화면 이동을 유지했습니다.
- 알림 생성 로직과 푸시 타입/extra 상수를 공통화했습니다.
- 로그인된 사용자가 홈에 진입한 상태에서만 리마인더가 활성화되고, 로그인/온보딩 상태에서는 비활성화되도록 정책을 한 곳으로 모았습니다.

## 배경
알림 권한을 허용한 사용자에게 매일 식사 기록을 유도하되, 로그아웃했거나 온보딩 중인 사용자에게는 리마인더가 계속 남지 않도록 하기 위한 변경입니다.

## 검증
- `./gradlew :app:testDebugUnitTest --tests com.nexters.fooddiary.push.DailyRecordReminderSchedulerTest`
- `./gradlew :app:compileDebugReleaseKotlin`

## 참고
- 로컬에서 `debugRelease` 설치를 하려면 worktree 루트에 `mumuk-dev.jks`가 필요합니다.
