### PR TITLE
fix(mypage): 마이페이지 알림 설정 상태 및 안내 추가

### DIFF
--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -17,6 +17,12 @@
     <string name="my_page_nick_name">%s님</string>
     <string name="my_page_section_alert">알림</string>
     <string name="my_page_menu_set_alarm">알림설정</string>
+    <string name="my_page_alarm_status_on">ON</string>
+    <string name="my_page_alarm_status_off">OFF</string>
+    <string name="my_page_alarm_state_enabled">알림 켜짐</string>
+    <string name="my_page_alarm_state_disabled">알림 꺼짐</string>
+    <string name="my_page_alarm_settings_dialog_message">알림을 끄면 분석 완료 알림을 받을 수 없어요.</string>
+    <string name="my_page_alarm_settings_dialog_confirm">설정으로 이동</string>
     <string name="my_page_section_setting">관리</string>
     <string name="my_page_menu_logout">로그아웃</string>
     <string name="my_page_menu_app_version">앱 버전  %s</string>

--- a/presentation/mypage/src/main/java/com/nexters/fooddiary/presentation/mypage/MypageScreen.kt
+++ b/presentation/mypage/src/main/java/com/nexters/fooddiary/presentation/mypage/MypageScreen.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -18,10 +20,15 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -29,12 +36,18 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.app.NotificationManagerCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.compose.collectAsStateWithLifecycle
@@ -48,6 +61,9 @@ import com.nexters.fooddiary.core.ui.R.drawable
 import com.nexters.fooddiary.core.ui.component.DetailScreenHeader
 import com.nexters.fooddiary.core.ui.theme.Color363347
 import com.nexters.fooddiary.core.ui.theme.Gray050
+import com.nexters.fooddiary.core.ui.theme.Gray300
+import com.nexters.fooddiary.core.ui.theme.Gray700
+import com.nexters.fooddiary.core.ui.theme.PrimBase
 import com.nexters.fooddiary.core.ui.theme.SdBase
 import com.nexters.fooddiary.domain.model.DeleteAccountError
 import com.nexters.fooddiary.domain.model.DeleteAccountException
@@ -142,11 +158,23 @@ internal fun MyPageScreen(
     onBack: () -> Unit = {}
 ) {
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
     val scrollState = rememberScrollState()
+    var isAlarmEnabled by remember {
+        mutableStateOf(NotificationManagerCompat.from(context).areNotificationsEnabled())
+    }
     val logoutDialogTitle = stringResource(string.my_page_logout_dialog_title)
     val logoutDialogMessage = stringResource(string.my_page_logout_dialog_message)
     val logoutDialogCancel = stringResource(string.my_page_logout_dialog_cancel)
     val logoutText = stringResource(string.my_page_menu_logout)
+    val alarmStatusText = stringResource(
+        if (isAlarmEnabled) string.my_page_alarm_status_on else string.my_page_alarm_status_off
+    )
+    val alarmStateDescription = stringResource(
+        if (isAlarmEnabled) string.my_page_alarm_state_enabled else string.my_page_alarm_state_disabled
+    )
+    val alarmSettingsDialogMessage = stringResource(string.my_page_alarm_settings_dialog_message)
+    val alarmSettingsDialogConfirm = stringResource(string.my_page_alarm_settings_dialog_confirm)
     val deleteDialogTitle = stringResource(string.my_page_delete_dialog_title)
     val deleteDialogMessage = stringResource(string.my_page_delete_dialog_message)
     val deleteDialogWarningDataDeleted =
@@ -157,6 +185,18 @@ internal fun MyPageScreen(
     val deleteDialogAgreement = stringResource(string.my_page_delete_dialog_agreement)
     val deleteDialogConfirm = stringResource(string.my_page_delete_dialog_confirm)
     val deleteDialogCancel = stringResource(string.my_page_delete_dialog_cancel)
+
+    DisposableEffect(lifecycleOwner, context) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                isAlarmEnabled = NotificationManagerCompat.from(context).areNotificationsEnabled()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
 
     Column(
         modifier = Modifier
@@ -183,7 +223,22 @@ internal fun MyPageScreen(
         ) {
             MyPageSubMenu(
                 menuName = stringResource(string.my_page_menu_set_alarm),
-                onClick = onNavigateToAlarmSettings
+                statusText = alarmStatusText,
+                stateDescription = alarmStateDescription,
+                onClick = {
+                    if (isAlarmEnabled) {
+                        onShowDialog(
+                            DialogData(
+                                message = alarmSettingsDialogMessage,
+                                confirmText = alarmSettingsDialogConfirm,
+                                dismissText = deleteDialogCancel,
+                                onConfirm = onNavigateToAlarmSettings
+                            )
+                        )
+                    } else {
+                        onNavigateToAlarmSettings()
+                    }
+                }
             )
         }
         MyPageSection(
@@ -321,18 +376,51 @@ internal fun MyPageSection(
 internal fun MyPageSubMenu(
     modifier: Modifier = Modifier,
     menuName: String = "",
+    statusText: String? = null,
+    stateDescription: String? = null,
     onClick: () -> Unit = {}
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
             .background(color = Color363347)
+            .semantics {
+                stateDescription?.let { this.stateDescription = it }
+            }
             .clickable { onClick() }
             .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        Text(text = menuName, color = Gray050)
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = menuName, color = Gray050)
+            statusText?.let { AlarmStatusBadge(statusText = it) }
+        }
         Image(painter = painterResource(drawable.ic_next), contentDescription = "next_button")
+    }
+}
+
+@Composable
+private fun RowScope.AlarmStatusBadge(statusText: String) {
+    val isEnabled = statusText == stringResource(string.my_page_alarm_status_on)
+    Surface(
+        shape = RoundedCornerShape(999.dp),
+        color = if (isEnabled) PrimBase else Gray700
+    ) {
+        Box(
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = statusText,
+                color = if (isEnabled) Gray050 else Gray300,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## 변경 사항

- 마이페이지의 `알림설정` 메뉴에 시스템 알림 활성 상태를 반영하는 `ON/OFF` 배지를 추가했습니다.
- 알림이 켜진 상태에서 알림 설정으로 이동할 때, 기존 공용 다이얼로그로 "알림을 끄면 분석 완료 알림을 받을 수 없어요." 안내를 먼저 보여주도록 변경했습니다.
- 시스템 알림 설정 화면에서 돌아오면 `ON/OFF` 상태가 다시 반영되도록 갱신 로직을 추가했습니다.
- 스크린 리더에서 `알림 켜짐/꺼짐` 상태를 읽을 수 있도록 접근성 상태 설명을 추가했습니다.

## 확인 사항

- `./gradlew :app:compileDebugKotlin`
