### PR TITLE
[FD-350] 공유하기 URL에 스토어 링크 분리 및 CTA 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -206,6 +206,7 @@ dependencies {
     // Firebase Cloud Messaging
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.messaging)
+    implementation(libs.firebase.remote.config)
 
     implementation(libs.sentry.android)
 

--- a/app/src/main/java/com/nexters/fooddiary/FoodDiaryApplication.kt
+++ b/app/src/main/java/com/nexters/fooddiary/FoodDiaryApplication.kt
@@ -3,14 +3,20 @@ package com.nexters.fooddiary
 import android.app.Application
 import android.util.Log
 import com.airbnb.mvrx.Mavericks
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import dagger.hilt.android.HiltAndroidApp
 import io.sentry.android.core.SentryAndroid
+import javax.inject.Inject
 
 @HiltAndroidApp
 class FoodDiaryApplication : Application() {
+    @Inject
+    lateinit var remoteConfig: FirebaseRemoteConfig
+
     override fun onCreate() {
         super.onCreate()
         Mavericks.initialize(this)
+        remoteConfig.fetchAndActivate()
         initSentry()
     }
 
@@ -28,4 +34,5 @@ class FoodDiaryApplication : Application() {
             }
             ?: Log.w("Sentry", "DSN 미설정. local.properties에 sentry.dsn 추가 후 Clean + Rebuild 필요.")
     }
+
 }

--- a/app/src/main/java/com/nexters/fooddiary/di/AppModule.kt
+++ b/app/src/main/java/com/nexters/fooddiary/di/AppModule.kt
@@ -1,11 +1,17 @@
 package com.nexters.fooddiary.di
 
+import com.google.firebase.Firebase
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.remoteConfig
+import com.google.firebase.remoteconfig.remoteConfigSettings
 import com.nexters.fooddiary.BuildConfig
+import com.nexters.fooddiary.R
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Named
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -17,4 +23,19 @@ object AppModule {
     @Provides
     @Named("useMockApi")
     fun provideUseMockApi(): Boolean = BuildConfig.USE_MOCK_API
+
+    @Provides
+    @Singleton
+    fun provideFirebaseRemoteConfig(): FirebaseRemoteConfig {
+        return Firebase.remoteConfig.apply {
+            setConfigSettingsAsync(
+                remoteConfigSettings {
+                    minimumFetchIntervalInSeconds = DEFAULT_REMOTE_CONFIG_FETCH_INTERVAL
+                }
+            )
+            setDefaultsAsync(R.xml.remote_config_defaults)
+        }
+    }
+
+    private const val DEFAULT_REMOTE_CONFIG_FETCH_INTERVAL = 3600L
 }

--- a/app/src/main/res/xml/remote_config_defaults.xml
+++ b/app/src/main/res/xml/remote_config_defaults.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<defaultsMap>
+    <entry>
+        <key>use_store_link</key>
+        <value>false</value>
+    </entry>
+</defaultsMap>

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -30,23 +30,38 @@ android {
 
         val apiBaseUrl = localOrEnv("api.base.url", "API_BASE_URL")
             .ifEmpty { "https://api.example.com/" }
+        val webBaseUrl = localOrEnv("web.base.url", "WEB_BASE_URL")
+            .ifEmpty { "https://mumuk.ai.kr/" }
 
         buildConfigField(
             "String",
             "API_BASE_URL",
             "\"$apiBaseUrl\""
         )
+        buildConfigField(
+            "String",
+            "WEB_BASE_URL",
+            "\"$webBaseUrl\""
+        )
     }
 
     buildTypes {
         release {
             val apiBaseUrl = localOrEnv("api.base.url", "API_BASE_URL")
+            val webBaseUrl = localOrEnv("web.base.url", "WEB_BASE_URL")
 
             if (apiBaseUrl.isNotBlank()) {
                 buildConfigField(
                     "String",
                     "API_BASE_URL",
                     "\"$apiBaseUrl\""
+                )
+            }
+            if (webBaseUrl.isNotBlank()) {
+                buildConfigField(
+                    "String",
+                    "WEB_BASE_URL",
+                    "\"$webBaseUrl\""
                 )
             }
         }
@@ -138,6 +153,7 @@ dependencies {
     implementation(libs.firebase.auth)
     implementation(libs.firebase.installations)
     implementation(libs.firebase.messaging)
+    implementation(libs.firebase.remote.config)
 
     // Google Sign-In
     implementation(libs.play.services.auth)

--- a/data/src/main/java/com/nexters/fooddiary/data/di/DataModule.kt
+++ b/data/src/main/java/com/nexters/fooddiary/data/di/DataModule.kt
@@ -1,11 +1,13 @@
 package com.nexters.fooddiary.data.di
 
 import com.google.firebase.auth.FirebaseAuth
+import com.nexters.fooddiary.data.BuildConfig
 import com.nexters.fooddiary.data.auth.GoogleSignInHelper
 import com.nexters.fooddiary.data.firebase.AndroidLoginDeviceInfoProvider
 import com.nexters.fooddiary.data.firebase.LoginDeviceInfoProvider
 import com.nexters.fooddiary.data.firebase.LoginFirebaseTokenProvider
 import com.nexters.fooddiary.data.firebase.LoginFirebaseTokenProviderImpl
+import com.nexters.fooddiary.data.remoteconfig.FirebaseShareConfigRepository
 import com.nexters.fooddiary.data.repository.DiaryRepositoryImpl
 import com.nexters.fooddiary.data.repository.ReviewPromptRepositoryImpl
 import com.nexters.fooddiary.data.repository.AuthRepositoryImpl
@@ -16,12 +18,14 @@ import com.nexters.fooddiary.core.common.resource.AndroidResourceProvider
 import com.nexters.fooddiary.domain.repository.AuthRepository
 import com.nexters.fooddiary.domain.repository.DiaryRepository
 import com.nexters.fooddiary.domain.repository.ReviewPromptRepository
+import com.nexters.fooddiary.domain.repository.ShareConfigRepository
 import com.nexters.fooddiary.domain.repository.UserRepository
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -76,9 +80,19 @@ abstract class DataModule {
         androidResourceProvider: AndroidResourceProvider
     ): ResourceProvider
 
+    @Binds
+    @Singleton
+    abstract fun bindShareConfigRepository(
+        firebaseShareConfigRepository: FirebaseShareConfigRepository
+    ): ShareConfigRepository
+
     companion object {
         @Provides
         @Singleton
         fun provideFirebaseAuth(): FirebaseAuth = FirebaseAuth.getInstance()
+
+        @Provides
+        @Named("shareBaseUrl")
+        fun provideShareBaseUrl(): String = BuildConfig.WEB_BASE_URL
     }
 }

--- a/data/src/main/java/com/nexters/fooddiary/data/remoteconfig/FirebaseShareConfigRepository.kt
+++ b/data/src/main/java/com/nexters/fooddiary/data/remoteconfig/FirebaseShareConfigRepository.kt
@@ -1,0 +1,26 @@
+package com.nexters.fooddiary.data.remoteconfig
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.nexters.fooddiary.domain.repository.ShareConfigRepository
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+class FirebaseShareConfigRepository @Inject constructor(
+    private val remoteConfig: FirebaseRemoteConfig,
+    @Named("shareBaseUrl") private val shareBaseUrl: String,
+) : ShareConfigRepository {
+    override fun getShareStoreLink(): String? {
+        val isEnabled = remoteConfig.getBoolean(KEY_SHARE_STORE_LINK_ENABLED)
+        if (!isEnabled) return null
+
+        return shareBaseUrl
+            .trim()
+            .takeIf { it.isNotBlank() }
+    }
+
+    private companion object {
+        const val KEY_SHARE_STORE_LINK_ENABLED = "use_store_link"
+    }
+}

--- a/data/src/test/java/com/nexters/fooddiary/data/remoteconfig/FirebaseShareConfigRepositoryTest.kt
+++ b/data/src/test/java/com/nexters/fooddiary/data/remoteconfig/FirebaseShareConfigRepositoryTest.kt
@@ -1,0 +1,48 @@
+package com.nexters.fooddiary.data.remoteconfig
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FirebaseShareConfigRepositoryTest {
+    private val remoteConfig = mockk<FirebaseRemoteConfig>()
+
+    @Test
+    fun `returns null when share store link is disabled`() {
+        val repository = FirebaseShareConfigRepository(
+            remoteConfig = remoteConfig,
+            shareBaseUrl = "https://mumuk.ai.kr/",
+        )
+        every { remoteConfig.getBoolean("use_store_link") } returns false
+
+        assertNull(repository.getShareStoreLink())
+    }
+
+    @Test
+    fun `returns null when configured base url is blank`() {
+        val repository = FirebaseShareConfigRepository(
+            remoteConfig = remoteConfig,
+            shareBaseUrl = "   ",
+        )
+        every { remoteConfig.getBoolean("use_store_link") } returns true
+
+        assertNull(repository.getShareStoreLink())
+    }
+
+    @Test
+    fun `returns trimmed base url when feature is enabled`() {
+        val repository = FirebaseShareConfigRepository(
+            remoteConfig = remoteConfig,
+            shareBaseUrl = " https://mumuk.ai.kr/ ",
+        )
+        every { remoteConfig.getBoolean("use_store_link") } returns true
+
+        assertEquals(
+            "https://mumuk.ai.kr/",
+            repository.getShareStoreLink()
+        )
+    }
+}

--- a/domain/src/main/kotlin/com/nexters/fooddiary/domain/repository/ShareConfigRepository.kt
+++ b/domain/src/main/kotlin/com/nexters/fooddiary/domain/repository/ShareConfigRepository.kt
@@ -1,0 +1,5 @@
+package com.nexters.fooddiary.domain.repository
+
+interface ShareConfigRepository {
+    fun getShareStoreLink(): String?
+}

--- a/domain/src/main/kotlin/com/nexters/fooddiary/domain/usecase/GetShareStoreLinkUseCase.kt
+++ b/domain/src/main/kotlin/com/nexters/fooddiary/domain/usecase/GetShareStoreLinkUseCase.kt
@@ -1,0 +1,10 @@
+package com.nexters.fooddiary.domain.usecase
+
+import com.nexters.fooddiary.domain.repository.ShareConfigRepository
+import javax.inject.Inject
+
+class GetShareStoreLinkUseCase @Inject constructor(
+    private val shareConfigRepository: ShareConfigRepository,
+) {
+    operator fun invoke(): String? = shareConfigRepository.getShareStoreLink()
+}

--- a/domain/src/test/kotlin/com/nexters/fooddiary/domain/usecase/GetShareStoreLinkUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/nexters/fooddiary/domain/usecase/GetShareStoreLinkUseCaseTest.kt
@@ -1,0 +1,35 @@
+package com.nexters.fooddiary.domain.usecase
+
+import com.nexters.fooddiary.domain.repository.ShareConfigRepository
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GetShareStoreLinkUseCaseTest {
+    @Test
+    fun `returns configured store link when available`() {
+        val useCase = GetShareStoreLinkUseCase(
+            shareConfigRepository = FakeShareConfigRepository("https://play.google.com/store/apps/details?id=com.example")
+        )
+
+        assertEquals(
+            "https://play.google.com/store/apps/details?id=com.example",
+            useCase()
+        )
+    }
+
+    @Test
+    fun `returns null when store link is unavailable`() {
+        val useCase = GetShareStoreLinkUseCase(
+            shareConfigRepository = FakeShareConfigRepository(null)
+        )
+
+        assertNull(useCase())
+    }
+
+    private class FakeShareConfigRepository(
+        private val storeLink: String?,
+    ) : ShareConfigRepository {
+        override fun getShareStoreLink(): String? = storeLink
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -148,6 +148,7 @@ firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
 firebase-installations = { group = "com.google.firebase", name = "firebase-installations" }
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
+firebase-remote-config = { group = "com.google.firebase", name = "firebase-config" }
 androidx-ui-tooling-preview-android = { group = "androidx.compose.ui", name = "ui-tooling-preview-android", version.ref = "uiToolingPreviewAndroid" }
 
 # Coil

--- a/presentation/detail/src/main/java/com/nexters/fooddiary/presentation/detail/DetailScreen.kt
+++ b/presentation/detail/src/main/java/com/nexters/fooddiary/presentation/detail/DetailScreen.kt
@@ -155,7 +155,17 @@ internal fun DetailScreen(
                         currentContext.getString(R.string.detail_share_place_fallback)
                     }
                     val prefixText = currentContext.getString(R.string.detail_share_prefix, placeText)
-                    val shareMessage = "$prefixText\n${event.mapLink}"
+                    val shareMessage = buildString {
+                        append(prefixText)
+                        append('\n')
+                        append(event.mapLink)
+                        event.storeLink?.takeIf { it.isNotBlank() }?.let { storeLink ->
+                            append('\n')
+                            append(currentContext.getString(R.string.detail_share_store_cta))
+                            append('\n')
+                            append(storeLink)
+                        }
+                    }
                     shareText(currentContext, shareMessage, currentContext.getString(R.string.detail_share))
                 }
                 DetailEvent.ShareLinkEmpty -> {

--- a/presentation/detail/src/main/java/com/nexters/fooddiary/presentation/detail/DetailViewModel.kt
+++ b/presentation/detail/src/main/java/com/nexters/fooddiary/presentation/detail/DetailViewModel.kt
@@ -10,6 +10,7 @@ import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.hilt.AssistedViewModelFactory
 import com.airbnb.mvrx.hilt.hiltMavericksViewModelFactory
+import com.nexters.fooddiary.domain.usecase.GetShareStoreLinkUseCase
 import com.nexters.fooddiary.domain.usecase.GetDiaryByDateUseCase
 import com.nexters.fooddiary.domain.usecase.diary.DeleteDiaryUseCase
 import com.nexters.fooddiary.presentation.detail.util.toDailyMeals
@@ -31,7 +32,7 @@ data class DetailState(
 
 sealed interface DetailEvent {
     data class CopyMapLink(val mapLink: String) : DetailEvent
-    data class ShareMapLink(val place: String, val mapLink: String) : DetailEvent
+    data class ShareMapLink(val place: String, val mapLink: String, val storeLink: String?) : DetailEvent
     data object ShareLinkEmpty : DetailEvent
     data class NavigateToImagePicker(val date: LocalDate) : DetailEvent
     data class NavigateToModify(val diaryId: String) : DetailEvent
@@ -44,6 +45,7 @@ class DetailViewModel @AssistedInject constructor(
     @Assisted initialState: DetailState,
     private val getDiaryByDateUseCase: GetDiaryByDateUseCase,
     private val deleteDiaryUseCase: DeleteDiaryUseCase,
+    private val getShareStoreLinkUseCase: GetShareStoreLinkUseCase,
 ) : MavericksViewModel<DetailState>(initialState) {
     private val _events = MutableSharedFlow<DetailEvent>(extraBufferCapacity = 1)
     val events: SharedFlow<DetailEvent> = _events.asSharedFlow()
@@ -170,7 +172,13 @@ class DetailViewModel @AssistedInject constructor(
             _events.tryEmit(DetailEvent.ShareLinkEmpty)
             return
         }
-        _events.tryEmit(DetailEvent.ShareMapLink(place = place, mapLink = mapLink))
+        _events.tryEmit(
+            DetailEvent.ShareMapLink(
+                place = place,
+                mapLink = mapLink,
+                storeLink = getShareStoreLinkUseCase(),
+            )
+        )
     }
 
     private fun putAndTrim(

--- a/presentation/detail/src/main/res/values/strings.xml
+++ b/presentation/detail/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="detail_share_map_link_empty">공유할 링크가 없어요.</string>
     <string name="detail_share_place_fallback">이곳</string>
     <string name="detail_share_prefix">%1$s 맛을 기억하시나요?\n뭐먹었지에서 확인해보세요.</string>
+    <string name="detail_share_store_cta">나도 시작하기</string>
     <string name="detail_ai_summary_title">AI가 요약했어요.</string>
     <string name="detail_place_empty_guide">수정버튼을 눌러 내용을 기록해주세요.</string>
     <string name="detail_menu_delete">전체삭제</string>


### PR DESCRIPTION
## 변경 내용
- Firebase Remote Config 플래그 `use_store_link`로 스토어 링크 노출 여부를 제어하도록 변경
- 공유용 웹 링크를 `web.base.url` 설정으로 분리하고 data/domain 계층으로 정리
- 상세 화면 공유 문구에 `나도 시작하기` CTA와 스토어 링크를 조건부로 추가
- Remote Config repository 및 use case 테스트를 추가

## 체크리스트
- [x] `./gradlew :domain:test`
- [x] `./gradlew :data:testDebugUnitTest --tests com.nexters.fooddiary.data.remoteconfig.FirebaseShareConfigRepositoryTest`
- [x] `./gradlew :data:compileDebugKotlin :presentation:detail:compileDebugKotlin :app:compileDebugKotlin`
- [x] 불필요한 파일 없음
