### PR TITLE
fix: [FD-357] 플로팅 버튼에 가려지지 않도록 상세 목록 하단 여백 추가

### DIFF
--- a/presentation/detail/src/main/java/com/nexters/fooddiary/presentation/detail/DetailScreen.kt
+++ b/presentation/detail/src/main/java/com/nexters/fooddiary/presentation/detail/DetailScreen.kt
@@ -101,6 +101,11 @@ private const val DailyHeaderInlineKey = "daily_header_inline"
 private const val GapAfterDailyHeaderKey = "gap_after_daily_header"
 private val DetailMealCardBackground = Color(0xFFF4F6FA)
 private val DetailMealNoteIconBackground = Color(0xFFFFF2E9)
+private val DetailFloatingButtonSize = 60.dp
+private val DetailFloatingButtonBottomPadding = 24.dp
+private val DetailListBottomPadding =
+    DetailFloatingButtonBottomPadding + DetailFloatingButtonSize + 20.dp
+
 @Composable
 internal fun DetailScreen(
     initialDateString: String = LocalDate.now().toString(),
@@ -283,7 +288,7 @@ private fun DetailContent(
                     .hazeSource(state = hazeState)
                     .background(AppBackground),
                 verticalArrangement = Arrangement.Top,
-                contentPadding = PaddingValues(bottom = 20.dp)
+                contentPadding = PaddingValues(bottom = DetailListBottomPadding)
             ) {
 
                 item(key = DetailHeaderKey) {
@@ -432,8 +437,8 @@ private fun DetailContent(
             IconButton(
                 modifier = Modifier
                     .align(Alignment.BottomEnd)
-                    .padding(end = 20.dp, bottom = 24.dp)
-                    .size(60.dp)
+                    .padding(end = 20.dp, bottom = DetailFloatingButtonBottomPadding)
+                    .size(DetailFloatingButtonSize)
                     .background(color = Color.White, shape = CircleShape),
                 onClick = onAddFloatingPhotoClick,
                 shape = CircleShape,


### PR DESCRIPTION
## 변경 내용
- lazyColumn item이 플로팅 버튼으로 인해 가려지는 현상 수정
- 패딩을 추가해 스크롤 범위 확대하여 수정

## ScreenShot
<img height="800" alt="screenshot-1783814177762" src="https://github.com/user-attachments/assets/c21bedb3-0100-4e9f-9706-5618fe3ef46b" />

## 체크리스트
- [ ] 빌드 정상 동작
- [ ] 불필요한 파일 없음

